### PR TITLE
Fix issue #4 (page is sometimes incorrectly read in as a string)

### DIFF
--- a/frontend/src/pages/JobsPage/JobsPage.jsx
+++ b/frontend/src/pages/JobsPage/JobsPage.jsx
@@ -321,6 +321,7 @@ class JobsPage extends React.Component {
         const queryParamsWithDefaults = {
             ...QUERY_PARAM_DEFAULTS,
             ...query,
+            page: query.page ? parseInt(query.page) : 0,
             selectedIds: query.selectedIds ? query.selectedIds.split(',') : []
         };
         this.props.setAndFetch(queryParamsWithDefaults);


### PR DESCRIPTION
If you refresh the page that has "page=N" (where N is some number), then Batchiepatchie will load it as a string.

When you press next page it'll end up doing stuff like "page + 1" which will do thing like "page=3" turn into "page=31" instead of "page=4".

This commit makes it so that the page is parsed as integer when loaded from query parameters.