### PR TITLE
Add link to CloudWatch logs

### DIFF
--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -58,6 +58,7 @@ class JobPage extends React.Component {
         } = this.props;
 
         const job = jobsById[id];
+        const jobRegion = job.task_arn.split(":")[3];
         const log = logsById[id] ? logsById[id].map(entry => entry.Message) : [];
         const terminalHeight = height - 440;
 
@@ -259,6 +260,21 @@ class JobPage extends React.Component {
                                     Download Logs
                                 </button>
                             </a>
+                            <a
+                                href={
+                                    "https://" +
+                                    jobRegion +
+                                    ".console.aws.amazon.com/cloudwatch/home?region=" +
+                                    jobRegion +
+                                    "#logEventViewer:group=/aws/batch/job;stream=" +
+                                    job.log_stream_name
+                                }
+                                target="_blank"
+                            >
+                            <button className="btn btn-xs btn-dark">
+                                Show logs in CloudWatch
+                            </button>
+                        </a>
                         </div>
                         <div className='col-md-3'>
                           { job.task_arn }

--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -58,7 +58,7 @@ class JobPage extends React.Component {
         } = this.props;
 
         const job = jobsById[id];
-        const jobRegion = job.task_arn.split(":")[3];
+        const jobRegion = job.task_arn === null ? null : job.task_arn.split(":")[3];
         const log = logsById[id] ? logsById[id].map(entry => entry.Message) : [];
         const terminalHeight = height - 440;
 
@@ -260,6 +260,7 @@ class JobPage extends React.Component {
                                     Download Logs
                                 </button>
                             </a>
+                            {job.log_stream_name === null || jobRegion === null ? <span /> :
                             <a
                                 href={
                                     "https://" +
@@ -271,10 +272,11 @@ class JobPage extends React.Component {
                                 }
                                 target="_blank"
                             >
-                            <button className="btn btn-xs btn-dark">
-                                Show logs in CloudWatch
-                            </button>
-                        </a>
+                                <button className="btn btn-xs btn-dark">
+                                    Show logs in CloudWatch
+                                </button>
+                            </a>
+                            }
                         </div>
                         <div className='col-md-3'>
                           { job.task_arn }


### PR DESCRIPTION
In the job page add a direct link to the logs in CloudWatch

![Screenshot 2020-03-11 at 12 53 24](https://user-images.githubusercontent.com/122749/76414299-4fe76e00-6397-11ea-97c6-bcf6f3523f45.png)
