### PR TITLE
Teach docker-compose.yml to pass AWS credentials from environment.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - BUILD_ENV=${BUILD_ENV}
       - BATCHIEPATCHIE_CONFIG=batchiepatchie-dockercompose-config.toml
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
     volumes:
       - .:/go/src/github.com/AdRoll/batchiepatchie
     ports:


### PR DESCRIPTION
The side effect is that this also makes documentation not say lies about how we pass these environment variables to `docker-compose`.

Addresses issue #31 
