### PR TITLE
Add temp var for search param to effectively debounce search

### DIFF
--- a/frontend/src/components/Search/Search.jsx
+++ b/frontend/src/components/Search/Search.jsx
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import debounce from 'utils/debounce';
 import {
     setParams,
-    setLocationToSearch,
-    setSearch
+    setLocationToSearch
 } from 'stores/job';
 import SectionLoader from 'components/SectionLoader/SectionLoader';
 import {
@@ -27,16 +26,15 @@ function getStatusKey(path) {
 class Search extends React.Component {
     static propTypes = {
         loading: PropTypes.bool.isRequired,
-        q: PropTypes.string.isRequired,
+        qTemp: PropTypes.string.isRequired,
         setParams: PropTypes.func.isRequired,
-        setSearch: PropTypes.func.isRequired,
         statusKey: PropTypes.string.isRequired,
     };
 
     render() {
         const {
             loading,
-            q
+            qTemp
         } = this.props;
 
         return (
@@ -54,8 +52,8 @@ class Search extends React.Component {
                                 type='text'
                                 className='form-control'
                                 onChange={ this.onChange }
-                                onKeyPress={ this.handleKeyPress }
-                                value={ q }
+                                onKeyPress={ this.onKeyPress }
+                                value={ qTemp }
                                 placeholder='Search Jobs...'
                             />
                         </div>
@@ -66,18 +64,15 @@ class Search extends React.Component {
     }
 
     onChange = (e) => {
-        this.props.setSearch(e.target.value);
-
-        if (this.props.statusKey === JOBS) {
-            this.fetchJobsPage();
-        }
+        this.props.setParams({qTemp: e.target.value});
+        this.search(e.target.value);
     }
 
-    fetchJobsPage = debounce(() => {
-        this.props.setParams({q: this.props.q});
-    }, 300)
+    search = debounce((q) => {
+        this.props.setParams({q});
+    }, 500)
 
-    handleKeyPress = (e) => {
+    onKeyPress = (e) => {
         if (e.key === 'Enter' && this.props.statusKey !== JOBS) {
             this.props.setLocationToSearch();
         }
@@ -88,15 +83,14 @@ const mapStateToProps = state => {
     const statusKey = getStatusKey(state.routing.locationBeforeTransitions.pathname);
     return {
         statusKey,
-        q: state.job.q,
+        qTemp: state.job.qTemp,
         loading: state.status[statusKey].loading
     };
 };
 
 const actions = {
     setParams,
-    setLocationToSearch,
-    setSearch
+    setLocationToSearch
 };
 
 export default connect(mapStateToProps, actions)(Search);

--- a/frontend/src/pages/JobsPage/JobsPage.jsx
+++ b/frontend/src/pages/JobsPage/JobsPage.jsx
@@ -309,6 +309,7 @@ class JobsPage extends React.Component {
         const queryParamsWithDefaults = {
             ...QUERY_PARAM_DEFAULTS,
             ...query,
+            qTemp: query.q || '',
             page: query.page ? parseInt(query.page) : 0,
             selectedIds: query.selectedIds ? query.selectedIds.split(',') : [],
             selectedQueue: !query.selectedQueue ? 'all' : query.selectedQueue,

--- a/frontend/src/stores/job.js
+++ b/frontend/src/stores/job.js
@@ -23,6 +23,7 @@ export const SET_LOGS = 'SET_LOGS';
 export const SET_PAGE = 'SET_PAGE';
 export const SET_QUEUES = 'SET_QUEUES';
 export const SET_SEARCH = 'SET_SEARCH';
+export const SET_SEARCH_TEMP = 'SET_SEARCH_TEMP';
 export const SET_SELECTED_IDS = 'SET_SELECTED_IDS';
 export const SET_SELECTED_QUEUE = 'SET_SELECTED_QUEUE';
 export const SET_SELECTED_STATUS = 'SET_SELECTED_STATUS';
@@ -134,6 +135,7 @@ const initialState = {
     logsById: {},
     page: 0,
     q: '',
+    qTemp: '',
     queues: [],
     selectedIds: [],
     selectedQueue: 'all',
@@ -209,6 +211,13 @@ actions[SET_SEARCH] = (state, { payload }) => {
     return {
         ...state,
         q: payload
+    };
+};
+
+actions[SET_SEARCH_TEMP] = (state, { payload }) => {
+    return {
+        ...state,
+        qTemp: payload
     };
 };
 
@@ -322,6 +331,13 @@ export function setSearch(q) {
     };
 };
 
+export function setSearchTemp(qTemp) {
+    return {
+        type: SET_SEARCH_TEMP,
+        payload: qTemp
+    };
+}
+
 export function setSelectedIds(selectedIds) {
     return {
         type: SET_SELECTED_IDS,
@@ -402,6 +418,9 @@ export function setParams(params) {
 
         if (params.q !== undefined)
             dispatch(setSearch(params.q));
+
+        if (params.qTemp !== undefined)
+            dispatch(setSearchTemp(params.qTemp));
 
         if (params.page !== undefined)
             dispatch(setPage(params.page));


### PR DESCRIPTION
This fixes search debouncing, which may inadvertently be a big performance issue with batchiepatchie (backend is trying to answer too many short queries at once... when it shouldn't need to).

#### Before
![batchiepatchie-not-debounced](https://user-images.githubusercontent.com/97663/94965218-17d98100-04c9-11eb-9ce3-5b7de6175493.gif)


#### After
![batchiepatchie-debounced](https://user-images.githubusercontent.com/97663/94965238-1f992580-04c9-11eb-963e-3e49cbbb6c3e.gif)