### PR TITLE
adding config option for database_root_certificate

### DIFF
--- a/batchiepatchie.go
+++ b/batchiepatchie.go
@@ -84,7 +84,7 @@ func main() {
 	}
 	opentracing.SetGlobalTracer(trace)
 
-	storage, err := jobs.NewPostgreSQLStore(config.Conf.DatabaseHost, config.Conf.DatabasePort, config.Conf.DatabaseUsername, config.Conf.DatabaseName, config.Conf.DatabasePassword)
+	storage, err := jobs.NewPostgreSQLStore(config.Conf.DatabaseHost, config.Conf.DatabasePort, config.Conf.DatabaseUsername, config.Conf.DatabaseName, config.Conf.DatabasePassword, config.Conf.DatabaseRootCertificate)
 	if err != nil {
 		log.Fatal("Creating postgresql store failed, ", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,21 +12,22 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/BurntSushi/toml"
 	"github.com/AdRoll/batchiepatchie/awsclients"
 	"github.com/AdRoll/batchiepatchie/envsubstituter"
 	"github.com/AdRoll/batchiepatchie/fetcher"
+	"github.com/BurntSushi/toml"
 	log "github.com/sirupsen/logrus"
 )
 
 type Config struct {
-	Port             int    `toml:"port"`
-	Host             string `toml:"host"`
-	DatabaseHost     string `toml:"database_host"`
-	DatabasePort     int    `toml:"database_port"`
-	DatabaseUsername string `toml:"database_username"`
-	DatabaseName     string `toml:"database_name"`
-	DatabasePassword string `toml:"database_password"`
+	Port                    int    `toml:"port"`
+	Host                    string `toml:"host"`
+	DatabaseHost            string `toml:"database_host"`
+	DatabasePort            int    `toml:"database_port"`
+	DatabaseUsername        string `toml:"database_username"`
+	DatabaseName            string `toml:"database_name"`
+	DatabasePassword        string `toml:"database_password"`
+	DatabaseRootCertificate string `toml:"database_root_certificate"`
 
 	LogEntriesKey string `toml:"logentries_token"`
 

--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -1355,9 +1355,9 @@ func (pq *postgreSQLStore) SubscribeToJobStatus(jobID string) (<-chan Job, func(
 func NewPostgreSQLStore(databaseHost string, databasePort int, databaseUsername string, databaseName string, databasePassword string, databaseRootCertificate string) (FinderStorer, error) {
 	var dbstr string
 	if databaseRootCertificate == "" {
-		dbstr = fmt.Sprintf("user=%s dbname=%s host=%s port=%d password=%s sslmode=verify-full sslrootcert=%s", databaseUsername, databaseName, databaseHost, databasePort, databasePassword, databaseRootCertificate)
-	} else {
 		dbstr = fmt.Sprintf("user=%s dbname=%s host=%s port=%d password=%s sslmode=disable", databaseUsername, databaseName, databaseHost, databasePort, databasePassword)
+	} else {
+		dbstr = fmt.Sprintf("user=%s dbname=%s host=%s port=%d password=%s sslmode=verify-full sslrootcert=%s", databaseUsername, databaseName, databaseHost, databasePort, databasePassword, databaseRootCertificate)
 	}
 
 	db, err := sql.Open("postgres", dbstr)

--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -1257,7 +1257,6 @@ func (pq *postgreSQLStore) JobStats(opts *JobStatsOptions) ([]*JobStats, error) 
 		query += ") "
 	}
 
-
 	if len(opts.Queues) > 0 {
 		query += " AND job_queue IN ("
 
@@ -1353,8 +1352,15 @@ func (pq *postgreSQLStore) SubscribeToJobStatus(jobID string) (<-chan Job, func(
 	return status_channel, unsubscribe
 }
 
-func NewPostgreSQLStore(databaseHost string, databasePort int, databaseUsername string, databaseName string, databasePassword string) (FinderStorer, error) {
-	db, err := sql.Open("postgres", fmt.Sprintf("user=%s dbname=%s host=%s port=%d sslmode=disable password=%s", databaseUsername, databaseName, databaseHost, databasePort, databasePassword))
+func NewPostgreSQLStore(databaseHost string, databasePort int, databaseUsername string, databaseName string, databasePassword string, databaseRootCertificate string) (FinderStorer, error) {
+	var dbstr string
+	if databaseRootCertificate == "" {
+		dbstr = fmt.Sprintf("user=%s dbname=%s host=%s port=%d password=%s sslmode=verify-full sslrootcert=%s", databaseUsername, databaseName, databaseHost, databasePort, databasePassword, databaseRootCertificate)
+	} else {
+		dbstr = fmt.Sprintf("user=%s dbname=%s host=%s port=%d password=%s sslmode=disable", databaseUsername, databaseName, databaseHost, databasePort, databasePassword)
+	}
+
+	db, err := sql.Open("postgres", dbstr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I added a config option called `database_root_cert` which should either (1) be left blank, defaulting to current behavior or (2) be the path to an SSL root certificate file. This allows you to utilize something like RDS IAM Authentication for the connection, by setting it to a value such as `/opt/rds-ca-2019-root.pem`.