### PR TITLE
Reduced trgm index on jobs table, exclude command_line / job_definition

### DIFF
--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -108,7 +108,7 @@ func (pq *postgreSQLStore) Find(opts *Options) ([]*Job, error) {
 		index := strconv.Itoa(len(args))
 
 		whereClausesScan = append(whereClausesScan, fmt.Sprintf(`
-			(job_id || job_name || job_queue || image || command_line || job_definition) LIKE $%s
+			(job_id || job_name || job_queue || image) LIKE $%s
 		`, index))
 	}
 

--- a/migrations/00022_reduced_trigram_index.sql
+++ b/migrations/00022_reduced_trigram_index.sql
@@ -1,15 +1,15 @@
 -- +goose Up
 -- SQL in this section is executed when the migration is applied.
-DROP INDEX trgm_idx_jobs;
+DROP INDEX CONCURRENTLY trgm_idx_jobs;
 
-CREATE INDEX trgm_idx_jobs ON jobs USING gin (
+CREATE INDEX CONCURRENTLY trgm_idx_jobs ON jobs USING gin (
     (job_id || job_name || job_queue || image) gin_trgm_ops
 );
 
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
-DROP INDEX trgm_idx_jobs;
+DROP INDEX CONCURRENTLY trgm_idx_jobs;
 
-CREATE INDEX trgm_idx_jobs ON jobs USING gin (
+CREATE INDEX CONCURRENTLY trgm_idx_jobs ON jobs USING gin (
     (job_id || job_name || job_queue || image || command_line || job_definition) gin_trgm_ops
 );

--- a/migrations/00022_reduced_trigram_index.sql
+++ b/migrations/00022_reduced_trigram_index.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+DROP INDEX trgm_idx_jobs;
+
+CREATE INDEX trgm_idx_jobs ON jobs USING gin (
+    (job_id || job_name || job_queue || image) gin_trgm_ops
+);
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+DROP INDEX trgm_idx_jobs;
+
+CREATE INDEX trgm_idx_jobs ON jobs USING gin (
+    (job_id || job_name || job_queue || image || command_line || job_definition) gin_trgm_ops
+);


### PR DESCRIPTION
**Goal**: Improve search performance by reducing index size.

AdRoll's implemention of this table over 60 million rows. At that scale, very wordy columns like "command_line" take up a lot of space in the index (it's approx. 35% of the table).

This removes the ability to search by `command_line` (large) or by `job_definition` (usually an opaque field users wouldn't be searching for).