### PR TITLE
Fix compilation error by making logentries host configurable.

### DIFF
--- a/batchiepatchie.go
+++ b/batchiepatchie.go
@@ -61,7 +61,11 @@ func main() {
 
 	if config.Conf.LogEntriesKey != "" {
 		log.Info("logentries_token supplied, will connect to LogEntries.")
-		setUpLogEntriesHooks(config.Conf.LogEntriesKey)
+		logentries_host := "data.logentries.com:443"
+		if config.Conf.LogEntriesHost != "" {
+			logentries_host = config.Conf.LogEntriesHost
+		}
+		setUpLogEntriesHooks(logentries_host, config.Conf.LogEntriesKey)
 	}
 
 	var trace opentracing.Tracer

--- a/config/config.go
+++ b/config/config.go
@@ -12,10 +12,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/BurntSushi/toml"
 	"github.com/AdRoll/batchiepatchie/awsclients"
 	"github.com/AdRoll/batchiepatchie/envsubstituter"
 	"github.com/AdRoll/batchiepatchie/fetcher"
+	"github.com/BurntSushi/toml"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,7 +28,8 @@ type Config struct {
 	DatabaseName     string `toml:"database_name"`
 	DatabasePassword string `toml:"database_password"`
 
-	LogEntriesKey string `toml:"logentries_token"`
+	LogEntriesHost string `toml:"logentries_host"`
+	LogEntriesKey  string `toml:"logentries_token"`
 
 	Region string `toml:"region"`
 

--- a/logentries.go
+++ b/logentries.go
@@ -5,8 +5,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func setUpLogEntriesHooks(key string) {
-	le, err := logentriesrus.NewLogentriesrusHook(key)
+func setUpLogEntriesHooks(host string, key string) {
+	le, err := logentriesrus.NewLogentriesrusHook(host, key)
 	if err != nil {
 		log.Fatal("Cannot connect to logentries: ", err)
 	}


### PR DESCRIPTION
A dependency has updated that changed how logentries logger is
initialized. You now need to provide a hostname when you instantiate
this logger.

This commit knows the default logentries host, and lets you override it
in configuration file if needed for whatever reason.

The new config item is called `logentries_host`.