### PR TITLE
Make "go get" display its progress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /go/src/github.com/AdRoll/batchiepatchie
 WORKDIR /go/src/github.com/AdRoll/batchiepatchie
 COPY . /go/src/github.com/AdRoll/batchiepatchie
 
-RUN go get
+RUN go get -v
 
 EXPOSE 5454
 EXPOSE 9999


### PR DESCRIPTION
The "go get" step in Dockerfile doesn't outpujt anything for several minutes. 

In this PR we make it verbose so we can see its progress.