### PR TITLE
Fix for database migration error

### DIFF
--- a/migrations/00022_reduced_trigram_index.sql
+++ b/migrations/00022_reduced_trigram_index.sql
@@ -1,3 +1,4 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- SQL in this section is executed when the migration is applied.
 DROP INDEX CONCURRENTLY trgm_idx_jobs;


### PR DESCRIPTION
This PR contains a fix for the error below. The fix is from https://bytemeta.vip/repo/pressly/goose/issues/292	

```
postgres_1    | ERROR:  DROP INDEX CONCURRENTLY cannot run inside a transaction block
postgres_1    | STATEMENT:  -- +goose Up
postgres_1    | 	-- SQL in this section is executed when the migration is applied.
postgres_1    | 	DROP INDEX CONCURRENTLY trgm_idx_jobs;
postgres_1    |
migrations_1  | 2022/07/25 22:13:01 goose run: failed to run SQL migration "00022_reduced_trigram_index.sql": failed to execute SQL query "DROP INDEX CONCURRENTLY trgm_idx_jobs;\n": pq: DROP INDEX CONCURRENTLY cannot run inside a transaction block
batchiepatchie_migrations_1 exited with code 1
```