### PR TITLE
Add back spinner

### DIFF
--- a/frontend/src/components/Search/Search.scss
+++ b/frontend/src/components/Search/Search.scss
@@ -1,5 +1,7 @@
 .search {
-    .ar-spinner {
+    .lds-spinner {
         float: right;
+        margin-right: -24px;
+        margin-top: 6px;
     }
 }

--- a/frontend/src/components/SectionLoader/SectionLoader.jsx
+++ b/frontend/src/components/SectionLoader/SectionLoader.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import './SectionLoader.scss';
 
 export default function SectionLoader() {
     return (
         <div className='section-loader'>
-            <div className='ar-spinner' />
+            <div className="lds-spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
         </div>
     );
 }

--- a/frontend/src/components/SectionLoader/SectionLoader.scss
+++ b/frontend/src/components/SectionLoader/SectionLoader.scss
@@ -1,0 +1,79 @@
+// Based on https://loading.io/css/
+.lds-spinner {
+  color: official;
+  display: inline-block;
+  position: relative;
+  width: 20px;
+  height: 20px;
+}
+.lds-spinner div {
+  transform-origin: 10px 10px;
+  animation: lds-spinner 1.2s linear infinite;
+}
+.lds-spinner div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 0.75px;
+  left: 9.25px;
+  width: 1.5px;
+  height: 4.5px;
+  border-radius: 20%;
+  background: black;
+}
+.lds-spinner div:nth-child(1) {
+  transform: rotate(0deg);
+  animation-delay: -1.1s;
+}
+.lds-spinner div:nth-child(2) {
+  transform: rotate(30deg);
+  animation-delay: -1s;
+}
+.lds-spinner div:nth-child(3) {
+  transform: rotate(60deg);
+  animation-delay: -0.9s;
+}
+.lds-spinner div:nth-child(4) {
+  transform: rotate(90deg);
+  animation-delay: -0.8s;
+}
+.lds-spinner div:nth-child(5) {
+  transform: rotate(120deg);
+  animation-delay: -0.7s;
+}
+.lds-spinner div:nth-child(6) {
+  transform: rotate(150deg);
+  animation-delay: -0.6s;
+}
+.lds-spinner div:nth-child(7) {
+  transform: rotate(180deg);
+  animation-delay: -0.5s;
+}
+.lds-spinner div:nth-child(8) {
+  transform: rotate(210deg);
+  animation-delay: -0.4s;
+}
+.lds-spinner div:nth-child(9) {
+  transform: rotate(240deg);
+  animation-delay: -0.3s;
+}
+.lds-spinner div:nth-child(10) {
+  transform: rotate(270deg);
+  animation-delay: -0.2s;
+}
+.lds-spinner div:nth-child(11) {
+  transform: rotate(300deg);
+  animation-delay: -0.1s;
+}
+.lds-spinner div:nth-child(12) {
+  transform: rotate(330deg);
+  animation-delay: 0s;
+}
+@keyframes lds-spinner {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
This PR adds a spinner back to BatchiePatchie. It seems to have had a spinner before (.ar-spinner) which got lost, probably when the repo moved from being a private repo to a public repo.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/90412347/180921354-e004b568-5660-488a-b3f4-62da99d3d2d8.png">
