### PR TITLE
Add tooltip explaining how search works

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
     "node-sass": "4.14.1",
+    "react-tooltip": "4.2.21",
     "react-dev-utils": "3.1.2",
     "react-error-overlay": "1.0.7",
     "sass-loader": "6.0.7",

--- a/frontend/src/components/Search/Search.jsx
+++ b/frontend/src/components/Search/Search.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import ReactTooltip from 'react-tooltip';
 import debounce from 'utils/debounce';
 import {
     setParams,
@@ -56,6 +57,16 @@ class Search extends React.Component {
                                 value={ qTemp }
                                 placeholder='Search Jobs...'
                             />
+                            <div className='search-info'>
+                                <div data-tip data-for="aboutSearch">
+                                    ℹ️
+                                </div>
+
+                                <ReactTooltip id="aboutSearch" place="left" effect="solid">
+                                    Search is case-insensitive, partial-word, AND search on individual words.<br />
+                                    The following fields are searched: ID, Name, Image, and Queue.
+                                </ReactTooltip>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/components/Search/Search.scss
+++ b/frontend/src/components/Search/Search.scss
@@ -5,3 +5,9 @@
         margin-top: 6px;
     }
 }
+
+.search-info {
+    font-size: 16px;
+    margin-left: 6px;
+    align-self: center;
+}


### PR DESCRIPTION
This adds a tooltip explaining how search works. This is for the new search implementation in https://github.com/AdRoll/batchiepatchie/pull/68/

<img width="500" alt="image" src="https://user-images.githubusercontent.com/90412347/181095424-60fefe8b-d9ea-49ff-b6ac-f43d56b08b9e.png">

<img width="533" alt="image" src="https://user-images.githubusercontent.com/90412347/181095893-aeb935fa-f2c7-4a3a-8a1f-4ba76dfa94de.png">
