### PR TITLE
add a  Link to batch job info

### DIFF
--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -256,13 +256,12 @@ class JobPage extends React.Component {
                                 Kill Job
                             </button>
                             <a
-                                href={
-                                    process.env.BASE_URL + "/api/v1/jobs/" + this.props.params.id  + "/logs?format=text"
-                                }
+                                href={process.env.BASE_URL + "/api/v1/jobs/" + this.props.params.id  + "/logs?format=text"}
                                 download={ this.props.params.id.substr(0, 8) + ".txt" }
-                                className='btn btn-info'
                             >
-                                Download Logs
+                                <button className='btn btn-xs btn-info'>
+                                    Download Logs
+                                </button>
                             </a>
                             {job.log_stream_name === null || jobRegion === null ? <span /> :
                             <a
@@ -276,7 +275,7 @@ class JobPage extends React.Component {
                                 }
                                 target="_blank"
                             >
-                                <button className='btn btn-dark'>
+                                <button className='btn btn-xs btn-dark'>
                                     Show logs in CloudWatch
                                 </button>
                             </a>
@@ -293,7 +292,7 @@ class JobPage extends React.Component {
                                 }
                                 target="_blank"
                             >
-                                <button className='btn btn-warning'>
+                                <button className='btn btn-xs btn-warning'>
                                     Show in AWS Batch
                                 </button>
                             </a>

--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -255,10 +255,14 @@ class JobPage extends React.Component {
                             <button className='btn btn-xs btn-danger' onClick={ this.killJob }>
                                 Kill Job
                             </button>
-                            <a href={process.env.BASE_URL + "/api/v1/jobs/" + this.props.params.id  + "/logs?format=text"} download={ this.props.params.id.substr(0, 8) + ".txt" }>
-                                <button className='btn btn-xs btn-info'>
-                                    Download Logs
-                                </button>
+                            <a
+                                href={
+                                    process.env.BASE_URL + "/api/v1/jobs/" + this.props.params.id  + "/logs?format=text"
+                                }
+                                download={ this.props.params.id.substr(0, 8) + ".txt" }
+                                className='btn btn-info'
+                            >
+                                Download Logs
                             </a>
                             {job.log_stream_name === null || jobRegion === null ? <span /> :
                             <a
@@ -272,8 +276,25 @@ class JobPage extends React.Component {
                                 }
                                 target="_blank"
                             >
-                                <button className="btn btn-xs btn-dark">
+                                <button className='btn btn-dark'>
                                     Show logs in CloudWatch
+                                </button>
+                            </a>
+                            }
+                            {job.id === null || jobRegion === null ? <span /> :
+                            <a
+                                href={
+                                    "https://" +
+                                    jobRegion +
+                                    ".console.aws.amazon.com/batch/home?region=" +
+                                    jobRegion +
+                                    "#jobs/detail/" +
+                                    job.id
+                                }
+                                target="_blank"
+                            >
+                                <button className='btn btn-warning'>
+                                    Show in AWS Batch
                                 </button>
                             </a>
                             }


### PR DESCRIPTION
If info we need is available, add button in job detail page that opens the job details in AWS Batch

<img width="378" alt="Screen Shot 2022-07-26 at 1 55 15 PM" src="https://user-images.githubusercontent.com/13129020/181100768-cce6ea61-2cfb-4fab-9418-6f951c977c44.png">
