### PR TITLE
Store array job info in the database

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -70,13 +70,13 @@ type ArrayProperties struct {
 }
 
 // Value implements the driver.Valuer interface. This method
-// simply returns the JSON-encoded representation of the struct.
+// is needed for JSONB serialization to the database.
 func (a ArrayProperties) Value() (driver.Value, error) {
 	return json.Marshal(a)
 }
 
 // Scan implements the sql.Scanner interface. This method
-// simply decodes a JSON-encoded value into the struct fields.
+// is needed for JSONB deserialization from the database.
 func (a *ArrayProperties) Scan(value interface{}) error {
 	b, ok := value.([]byte)
 	if !ok {

--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -387,6 +387,28 @@ func (pq *postgreSQLStore) Store(jobs []*Job) error {
 		defer final()
 		inserts_and_updates := 0
 		for _, job := range jobs {
+			extra_where_check := ""
+			if job.ArrayProperties != nil {
+				// extra_where_check is included in the update statement to minimize the number of updates.
+				extra_where_check = fmt.Sprintf(`
+					or jobs.array_properties is null
+					or (jobs.array_properties->'status_summary'->>'STARTING')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'FAILED')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'RUNNING')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'SUCCEEDED')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'RUNNABLE')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'SUBMITTED')::numeric != %d
+					or (jobs.array_properties->'status_summary'->>'PENDING')::numeric != %d
+					`,
+					job.ArrayProperties.StatusSummary.Starting,
+					job.ArrayProperties.StatusSummary.Failed,
+					job.ArrayProperties.StatusSummary.Running,
+					job.ArrayProperties.StatusSummary.Succeeded,
+					job.ArrayProperties.StatusSummary.Runnable,
+					job.ArrayProperties.StatusSummary.Submitted,
+					job.ArrayProperties.StatusSummary.Pending,
+				)
+			}
 			if job.StoppedAt == nil {
 				query := `insert into jobs (
 			  job_id,
@@ -405,10 +427,12 @@ func (pq *postgreSQLStore) Store(jobs []*Job) error {
 		          run_started_at,
 		          exitcode,
 		          log_stream_name,
-		          task_arn)
-			  values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-		      on conflict (job_id) do update set status = $6, last_updated = $12, status_reason = $13, run_started_at = $14, exitcode = $15, log_stream_name = $16, task_arn = $17
-		      where jobs.status <> $6 or jobs.status_reason <> $13 or jobs.exitcode <> $15 or jobs.log_stream_name <> $16 or jobs.task_arn <> $17 or (jobs.task_arn is null and $17 is not null) or (jobs.log_stream_name is null and $16 is not null) or (jobs.status_reason is null and $13 is not null) or (jobs.exitcode is null and $15 is not null)`
+		          task_arn,
+				  array_properties)
+			  values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+		      on conflict (job_id) do update set status = $6, last_updated = $12, status_reason = $13, run_started_at = $14, exitcode = $15, log_stream_name = $16, task_arn = $17, array_properties = $18
+		      where jobs.status <> $6 or jobs.status_reason <> $13 or jobs.exitcode <> $15 or jobs.log_stream_name <> $16 or jobs.task_arn <> $17 or (jobs.task_arn is null and $17 is not null) or (jobs.log_stream_name is null and $16 is not null) or (jobs.status_reason is null and $13 is not null) or (jobs.exitcode is null and $15 is not null)
+			  ` + extra_where_check
 				result, err := transaction.Exec(
 					query,
 					job.Id,
@@ -427,7 +451,8 @@ func (pq *postgreSQLStore) Store(jobs []*Job) error {
 					job.RunStartTime,
 					job.ExitCode,
 					job.LogStreamName,
-					job.TaskARN)
+					job.TaskARN,
+					job.ArrayProperties)
 				if err != nil {
 					log.Warning(err, ": ", job)
 					return err
@@ -457,10 +482,12 @@ func (pq *postgreSQLStore) Store(jobs []*Job) error {
 		          run_started_at,
 		          exitcode,
 		          log_stream_name,
-		          task_arn)
-			  values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-		      on conflict (job_id) do update set status = $6, last_updated = $13, stopped_at = $8, status_reason = $14, run_started_at = $15, exitcode = $16, log_stream_name = $17, task_arn = $18
-		      where jobs.status <> $6 or jobs.status_reason <> $14 or jobs.exitcode <> $16 or jobs.log_stream_name <> $17 or jobs.task_arn <> $18 or (jobs.task_arn is null and $18 is not null) or (jobs.log_stream_name is null and $17 is not null) or (jobs.status_reason is null and $14 is not null) or (jobs.exitcode is null and $16 is not null)`
+		          task_arn,
+				  array_properties)
+			  values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		      on conflict (job_id) do update set status = $6, last_updated = $13, stopped_at = $8, status_reason = $14, run_started_at = $15, exitcode = $16, log_stream_name = $17, task_arn = $18, array_properties = $19
+		      where jobs.status <> $6 or jobs.status_reason <> $14 or jobs.exitcode <> $16 or jobs.log_stream_name <> $17 or jobs.task_arn <> $18 or (jobs.task_arn is null and $18 is not null) or (jobs.log_stream_name is null and $17 is not null) or (jobs.status_reason is null and $14 is not null) or (jobs.exitcode is null and $16 is not null)
+			  ` + extra_where_check
 				result, err := transaction.Exec(
 					query,
 					job.Id,
@@ -480,7 +507,8 @@ func (pq *postgreSQLStore) Store(jobs []*Job) error {
 					job.RunStartTime,
 					job.ExitCode,
 					job.LogStreamName,
-					job.TaskARN)
+					job.TaskARN,
+					job.ArrayProperties)
 				if err != nil {
 					log.Warning(err, ": ", job)
 					return err

--- a/migrations/00023_add_array_properties_column.sql
+++ b/migrations/00023_add_array_properties_column.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+ALTER TABLE jobs ADD COLUMN array_properties JSONB;
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+
+ALTER TABLE jobs DROP COLUMN array_properties;

--- a/syncer/batchsync.go
+++ b/syncer/batchsync.go
@@ -208,25 +208,40 @@ func syncJobsStatus(storer jobs.Storer, status string, queues []string, job_summ
 					}
 				}
 
+				var array_properties *jobs.ArrayProperties
+				is_parent_array_job := desc.ArrayProperties != nil && desc.ArrayProperties.Size != nil
+				if is_parent_array_job {
+					array_properties = new(jobs.ArrayProperties)
+					array_properties.Size = *desc.ArrayProperties.Size
+					array_properties.StatusSummary.Starting = *desc.ArrayProperties.StatusSummary["STARTING"]
+					array_properties.StatusSummary.Failed = *desc.ArrayProperties.StatusSummary["FAILED"]
+					array_properties.StatusSummary.Running = *desc.ArrayProperties.StatusSummary["RUNNING"]
+					array_properties.StatusSummary.Succeeded = *desc.ArrayProperties.StatusSummary["SUCCEEDED"]
+					array_properties.StatusSummary.Runnable = *desc.ArrayProperties.StatusSummary["RUNNABLE"]
+					array_properties.StatusSummary.Submitted = *desc.ArrayProperties.StatusSummary["SUBMITTED"]
+					array_properties.StatusSummary.Pending = *desc.ArrayProperties.StatusSummary["PENDING"]
+				}
+
 				jobs_to_insert = append(jobs_to_insert, &jobs.Job{
-					Id:            *job.JobId,
-					Name:          *job.JobName,
-					Status:        *desc.Status,
-					Description:   *desc.JobDefinition,
-					LastUpdated:   time.Now().UTC(),
-					JobQueue:      queue,
-					Image:         image,
-					CreatedAt:     time.Unix(*desc.CreatedAt/1000, (*desc.CreatedAt%1000)*1000000).UTC(),
-					StoppedAt:     stopped_at,
-					VCpus:         vcpus,
-					Memory:        memory,
-					CommandLine:   string(command_line_json),
-					Timeout:       timeout,
-					StatusReason:  &status_reason,
-					RunStartTime:  run_started_time,
-					ExitCode:      exit_code,
-					LogStreamName: log_stream_name,
-					TaskARN:       task_arn,
+					Id:              *job.JobId,
+					Name:            *job.JobName,
+					Status:          *desc.Status,
+					Description:     *desc.JobDefinition,
+					LastUpdated:     time.Now().UTC(),
+					JobQueue:        queue,
+					Image:           image,
+					CreatedAt:       time.Unix(*desc.CreatedAt/1000, (*desc.CreatedAt%1000)*1000000).UTC(),
+					StoppedAt:       stopped_at,
+					VCpus:           vcpus,
+					Memory:          memory,
+					CommandLine:     string(command_line_json),
+					Timeout:         timeout,
+					StatusReason:    &status_reason,
+					RunStartTime:    run_started_time,
+					ExitCode:        exit_code,
+					LogStreamName:   log_stream_name,
+					TaskARN:         task_arn,
+					ArrayProperties: array_properties,
 				})
 			}
 		}


### PR DESCRIPTION
AWS returns counts of child array jobs like this:

```
"arrayProperties": {
    "statusSummary": {
        "STARTING": 0,
        "FAILED": 0,
        "RUNNING": 1,
        "SUCCEEDED": 99,
        "RUNNABLE": 0,
        "SUBMITTED": 0,
        "PENDING": 0
    },
    "size": 100
},
```

This PR puts this JSON in the jobs table in a JSONB column names array_properties.

We will use this data in an upcoming PR for reporting the statuses of child array jobs.

Note to @jcshott: This PR is easiest reviewed with [whitespace hidden](https://github.com/AdRoll/batchiepatchie/pull/75/files?diff=unified&w=1).