### PR TITLE
Try harder to get jobRegion

### DIFF
--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -58,7 +58,13 @@ class JobPage extends React.Component {
         } = this.props;
 
         const job = jobsById[id];
-        const jobRegion = (job === undefined || job === null || job.task_arn === null) ? null : job.task_arn.split(":")[3];
+        let jobRegion = (job === undefined || job === null || job.task_arn === null) ? null : job.task_arn.split(":")[3];
+        if (!jobRegion && job && job.desc) {
+            const matches = /^arn:aws:batch:([^:]+)/.exec(job.desc);
+            if (matches) {
+                jobRegion = matches[1];
+            }
+        }
         const log = logsById[id] ? logsById[id].map(entry => entry.Message) : [];
         const terminalHeight = height - 440;
 


### PR DESCRIPTION
If a job has no task_arn (like array jobs), extract the region from the desc, so that the Show in AWS Batch button will show up.

job.desc looks like this:
```
arn:aws:batch:us-west-2:11111111111:job-definition/foo-bar-baz:3
```