### PR TITLE
Add option to auto-scroll log to the bottom

### DIFF
--- a/frontend/src/components/Terminal/Terminal.jsx
+++ b/frontend/src/components/Terminal/Terminal.jsx
@@ -10,13 +10,17 @@ const CHAR_WIDTH = 8;
 export default class Terminal extends React.Component {
     static propTypes = {
         height: PropTypes.number.isRequired,
+        autoScrollToBottom: PropTypes.bool.isRequired,
         log: PropTypes.array.isRequired
     };
 
     render() {
-        const { log, height } = this.props;
+        const { log, height, autoScrollToBottom } = this.props;
         const maxLength = log.reduce((memo, item) => Math.max(memo, item.length), 0);
-
+        let listProps = {};
+        if (autoScrollToBottom) {
+            listProps = { scrollToIndex: log.length-1 };
+        }
         return (
             <div className='terminal'>
                 <AutoSizer disableHeight>
@@ -30,6 +34,7 @@ export default class Terminal extends React.Component {
                             rowHeight={ LOG_ROW_HEIGHT }
                             rowRenderer={ this.rowRenderer }
                             width={ Math.max(width, maxLength * CHAR_WIDTH) }
+                            {...listProps}
                         />
                     ) }
                 </AutoSizer>

--- a/frontend/src/pages/JobPage/JobPage.jsx
+++ b/frontend/src/pages/JobPage/JobPage.jsx
@@ -32,6 +32,13 @@ class JobPage extends React.Component {
         status: PropTypes.object.isRequired
     };
 
+    constructor(props) {
+        super(props);
+        this.state = {
+            autoScrollToBottom: true,
+        };
+    }
+
     componentDidMount() {
         this.props.fetchJobPage(this.props.params.id);
         this.props.fetchJobLogs(this.props.params.id);
@@ -57,6 +64,7 @@ class JobPage extends React.Component {
             height,
             status
         } = this.props;
+        const { autoScrollToBottom } = this.state;
 
         const job = jobsById[id];
         let jobRegion = (job === undefined || job === null || job.task_arn === null) ? null : job.task_arn.split(":")[3];
@@ -363,13 +371,20 @@ class JobPage extends React.Component {
                     <div className='row'>
                         <div className='col-md-12'>
                             <h2>Logs</h2>
+                            <label className="auto-scroll-checkbox">
+                                <input type="checkbox"
+                                    defaultChecked={autoScrollToBottom}
+                                    onChange={() => this.setState({autoScrollToBottom: !autoScrollToBottom})}
+                                />
+                                Auto-scroll to bottom
+                            </label>
                             { logStatus.loading && <SectionLoader /> }
                         </div>
                     </div>
 
                     <div className='row'>
                         <div className='col-md-12'>
-                            <Terminal log={ log } height={ terminalHeight } />
+                            <Terminal log={ log } height={ terminalHeight } autoScrollToBottom={ autoScrollToBottom } />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/JobPage/JobPage.scss
+++ b/frontend/src/pages/JobPage/JobPage.scss
@@ -30,4 +30,13 @@
             margin-top: 3px;
         }
     }
+
+    .auto-scroll-checkbox {
+        margin-top: 12px;
+        margin-left: 12px;
+
+        input {
+            margin-right: 3px;
+        }
+    }
 }


### PR DESCRIPTION
Add a checkbox for auto-scrolling log output to the bottom when there are new logs.

<img width="402" alt="image" src="https://user-images.githubusercontent.com/90412347/181349510-af5d41e8-feb0-4888-9485-987c876036ae.png">
