### PR TITLE
Sort queues in QueueSelector & fix sorting on stats page table

### DIFF
--- a/frontend/src/components/QueueSelector/QueueSelector.jsx
+++ b/frontend/src/components/QueueSelector/QueueSelector.jsx
@@ -20,7 +20,7 @@ class QueueSelector extends React.Component {
                     disabled={ false }
                     multi
                     onChange={ this.props.setSelectedQueue }
-                    options={ this.props.queues.map(q => ({ label: q, value: q })) }
+                    options={ this.props.queues.sort().map(q => ({ label: q, value: q })) }
                     placeholder='Queue'
                     value={ this.props.selectedQueue }
                     simpleValue

--- a/frontend/src/pages/StatsPage/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage/StatsPage.jsx
@@ -321,7 +321,7 @@ class StatsPage extends React.Component {
             return chartData[timestamp];
         });
 
-        const jobQueuesSorted = Object.keys(jobQueues).sort((a, b) => jobQueues[b] - jobQueues[a]);
+        const jobQueuesSorted = Object.keys(jobQueues).sort();
         return [chartDataFlat, tableData, totalData, jobQueuesSorted];
     }
 


### PR DESCRIPTION
use native sort() method since it's all just list of strings so nothing fancy needed.

**Before === anarchy** 🙀 

<img width="437" alt="Screen Shot 2022-07-27 at 1 28 54 PM" src="https://user-images.githubusercontent.com/13129020/181358818-7ea8ecf8-7dff-4143-9454-ae844de850c4.png">

<img width="392" alt="Screen Shot 2022-07-27 at 1 39 01 PM" src="https://user-images.githubusercontent.com/13129020/181358893-49ef0008-a7e7-49e9-8033-8c13737f96e6.png">


**After === order** 😌 

<img width="460" alt="Screen Shot 2022-07-27 at 1 29 19 PM" src="https://user-images.githubusercontent.com/13129020/181359183-dbc04aaa-4824-47d0-b75f-b219194a021a.png">

<img width="423" alt="Screen Shot 2022-07-27 at 1 39 29 PM" src="https://user-images.githubusercontent.com/13129020/181359220-111a7bfb-b8a3-43a4-afe0-bdbf8a5c7165.png">
