### PR TITLE
Use -buildvcs=false option

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -39,7 +39,7 @@ fi;
 
 if [ "${BUILD_ENV_ENV}" = "PRODUCTION" ]; then
     sleep 5
-    go build
+    go build -buildvcs=false
     ./batchiepatchie
 else
     sleep 5


### PR DESCRIPTION
Add the -buildvcs=false option. Hoping this will get us past the following error when we try to deploy the service to ECS:

```
2022-07-27T23:02:14.408126585Z + sleep 5
2022-07-27T23:02:19.409570176Z + go build
2022-07-27T23:02:19.573653063Z error obtaining VCS status: exit status 128
2022-07-27T23:02:19.573685073Z 	Use -buildvcs=false to disable VCS stamping.
```

More info: https://github.com/microsoft/CBL-Mariner/issues/3273

