### PR TITLE
Use basepath to determine if we are on index (jobs) page for search

### DIFF
--- a/frontend/src/containers/LayoutContainer/LayoutContainer.jsx
+++ b/frontend/src/containers/LayoutContainer/LayoutContainer.jsx
@@ -8,7 +8,7 @@ import './LayoutContainer.scss';
 class LayoutContainer extends React.Component {
     static propTypes = {
         children: PropTypes.element.isRequired,
-        location: PropTypes.object.isRequired,
+        path: PropTypes.string.isRequired,
         setPageDimensions: PropTypes.func.isRequired
     };
 
@@ -22,7 +22,7 @@ class LayoutContainer extends React.Component {
     }
 
     render() {
-        const onJobsPage = this.props.location.pathname === '/';
+        const onJobsPage = this.props.path === process.env.BASE_URL + '/';
         return (
             <div className='layout-container container-fluid'>
                 <div className='row'>
@@ -54,7 +54,9 @@ class LayoutContainer extends React.Component {
     }
 }
 
-const mapStateToProps = state => ({});
+const mapStateToProps = state => ({
+    path: state.routing.locationBeforeTransitions.pathname
+});
 
 const actions = {
     setPageDimensions


### PR DESCRIPTION
- fix bug where if the index/base path is not `/` the search bar doesn't show
- uses same check for path that the menu component uses: https://github.com/AdRoll/batchiepatchie/blob/master/frontend/src/components/Menu/Menu.jsx#L10

we use `/batchiepatchie/` as basepath so the original check for pathname of index page wasn't correct in non-local env (where it's just `/`):

Production (not showing search):

<img width="575" alt="Screen Shot 2022-07-28 at 9 14 31 AM" src="https://user-images.githubusercontent.com/13129020/181577455-346701c3-0e9f-4a32-bef7-c214fc8c985e.png">

v. local:

<img width="207" alt="Screen Shot 2022-07-28 at 9 30 54 AM" src="https://user-images.githubusercontent.com/13129020/181577837-db738b77-121d-41b1-b8ba-36d3a01032de.png">

