### PR TITLE
Override CSS property of the frozen header

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -88,3 +88,14 @@ pre {
 .Select-menu {
     max-height: 400px;
 }
+
+// override stickiness of checkbox-select frozen header row:
+// https://github.com/adazzle/react-data-grid/issues/1386#issuecomment-510532495
+// the full select column isn't frozen so alignment gets off during horizontal scrolling
+.react-grid-Row .react-grid-Cell--frozen {
+    transform: translate3d(0px, 0px, 0px) !important;
+}
+
+.react-grid-HeaderRow .react-grid-HeaderCell--frozen {
+    transform: translate3d(0px, 0px, 0px) !important;
+}


### PR DESCRIPTION
- the "select" column (checkboxes) are frozen by default but only the header row actually freezes.
- this causes the alignment to get off and looks weird when scrolling horizontally
- override the transform property of the frozen columns so they aren't frozen

I saw a few issues around the scrolling and the select column stickiness - [this was the simplest](https://github.com/adazzle/react-data-grid/issues/1386#issuecomment-510532495) (if not a bit hacky) answer outside of upgrading to v7+ which I'm not prepared to do here.

Seems relatively low-risk as we aren't using frozen columns anywhere else.

Current:

![scroll-off](https://user-images.githubusercontent.com/13129020/181624005-0764aee0-4760-4516-b154-39de15a27583.gif)

Fixed:

![scroll-fix](https://user-images.githubusercontent.com/13129020/181624434-793fef70-3135-48f4-8657-9c9b30a1dd6a.gif)

