### PR TITLE
changed data types of task_arns_to_instance_info

### DIFF
--- a/migrations/00013_add_task_arn_instance_id_table.sql
+++ b/migrations/00013_add_task_arn_instance_id_table.sql
@@ -4,8 +4,8 @@
 CREATE TABLE task_arns_to_instance_info (
     task_arn     TEXT NOT NULL,
     instance_id  TEXT NOT NULL,
-    public_ip    TEXT NOT NULL,
-    private_ip   TEXT NOT NULL,
+    public_ip    TEXT,
+    private_ip   TEXT,
     PRIMARY KEY(task_arn, instance_id)
 );
 


### PR DESCRIPTION
removed not null enforcement for ip columns in postgres tables to allow ip and instance ids to be populated