### PR TITLE
Submit search when user presses Enter

### DIFF
--- a/frontend/src/components/Search/Search.jsx
+++ b/frontend/src/components/Search/Search.jsx
@@ -52,6 +52,7 @@ class Search extends React.Component {
                                 type='text'
                                 className='form-control'
                                 onChange={ this.onChange }
+                                onKeyDown={ this.onKeyDown }
                                 value={ qTemp }
                                 placeholder='Search Jobs...'
                             />
@@ -64,12 +65,13 @@ class Search extends React.Component {
 
     onChange = (e) => {
         this.props.setParams({qTemp: e.target.value});
-        this.search(e.target.value);
     }
 
-    search = debounce((q) => {
-        this.props.setParams({q});
-    }, 500)
+    onKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            this.props.setParams({q: e.target.value});
+        }
+    }
 };
 
 const mapStateToProps = state => {


### PR DESCRIPTION
Submit the search when the user presses Enter instead of on every keypress. queries are expensive, so we don't want to do them on every keypress.