### PR TITLE
Rename q to startsWith

### DIFF
--- a/frontend/src/components/Search/Search.jsx
+++ b/frontend/src/components/Search/Search.jsx
@@ -26,7 +26,7 @@ function getStatusKey(path) {
 class Search extends React.Component {
     static propTypes = {
         loading: PropTypes.bool.isRequired,
-        qTemp: PropTypes.string.isRequired,
+        startsWithTemp: PropTypes.string.isRequired,
         setParams: PropTypes.func.isRequired,
         statusKey: PropTypes.string.isRequired,
     };
@@ -34,7 +34,7 @@ class Search extends React.Component {
     render() {
         const {
             loading,
-            qTemp
+            startsWithTemp
         } = this.props;
 
         return (
@@ -52,9 +52,9 @@ class Search extends React.Component {
                                 type='text'
                                 className='form-control'
                                 onChange={ this.onChange }
-                                onKeyDown={ this.onKeyDown }
-                                value={ qTemp }
-                                placeholder='Search Jobs...'
+                                onKeyDown={ this.onStartsWithKeyDown }
+                                value={ startsWithTemp }
+                                placeholder='Starts with...'
                             />
                         </div>
                     </div>
@@ -64,12 +64,12 @@ class Search extends React.Component {
     }
 
     onChange = (e) => {
-        this.props.setParams({qTemp: e.target.value});
+        this.props.setParams({startsWithTemp: e.target.value});
     }
 
-    onKeyDown = (e) => {
+    onStartsWithKeyDown = (e) => {
         if (e.key === 'Enter') {
-            this.props.setParams({q: e.target.value});
+            this.props.setParams({startsWith: e.target.value});
         }
     }
 };
@@ -78,7 +78,7 @@ const mapStateToProps = state => {
     const statusKey = getStatusKey(state.routing.locationBeforeTransitions.pathname);
     return {
         statusKey,
-        qTemp: state.job.qTemp,
+        startsWithTemp: state.job.startsWithTemp,
         loading: state.status[statusKey].loading
     };
 };

--- a/frontend/src/pages/JobsPage/JobsPage.jsx
+++ b/frontend/src/pages/JobsPage/JobsPage.jsx
@@ -125,7 +125,7 @@ class JobsPage extends React.Component {
         height: PropTypes.number.isRequired,
         jobs: PropTypes.array.isRequired,
         killJobs: PropTypes.func.isRequired,
-        q: PropTypes.string,
+        startsWith: PropTypes.string,
         routing: PropTypes.object.isRequired,
         selectedIds: PropTypes.array.isRequired,
         setParams: PropTypes.func.isRequired,
@@ -152,7 +152,7 @@ class JobsPage extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.q !== prevProps.q ||
+        if (this.props.startsWith !== prevProps.startsWith ||
             this.props.sortColumn !== prevProps.sortColumn ||
             this.props.sortDirection !== prevProps.sortDirection ||
             this.props.page !== prevProps.page ||
@@ -314,7 +314,7 @@ class JobsPage extends React.Component {
         const queryParamsWithDefaults = {
             ...QUERY_PARAM_DEFAULTS,
             ...query,
-            qTemp: query.q || '',
+            startsWithTemp: query.startsWith || '',
             page: query.page ? parseInt(query.page) : 0,
             selectedIds: query.selectedIds ? query.selectedIds.split(',') : [],
             selectedQueue: !query.selectedQueue ? 'all' : query.selectedQueue,
@@ -342,7 +342,7 @@ class JobsPage extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    q: state.job.q,
+    startsWith: state.job.startsWith,
     jobs: state.job.jobs,
     page: state.job.page,
     height: state.layout.height,

--- a/frontend/src/stores/job.js
+++ b/frontend/src/stores/job.js
@@ -22,8 +22,8 @@ export const SET_JOBS = 'SET_JOBS';
 export const SET_LOGS = 'SET_LOGS';
 export const SET_PAGE = 'SET_PAGE';
 export const SET_QUEUES = 'SET_QUEUES';
-export const SET_SEARCH = 'SET_SEARCH';
-export const SET_SEARCH_TEMP = 'SET_SEARCH_TEMP';
+export const SET_STARTS_WITH = 'SET_STARTS_WITH';
+export const SET_STARTS_WITH_TEMP = 'SET_STARTS_WITH_TEMP';
 export const SET_SELECTED_IDS = 'SET_SELECTED_IDS';
 export const SET_SELECTED_QUEUE = 'SET_SELECTED_QUEUE';
 export const SET_SELECTED_STATUS = 'SET_SELECTED_STATUS';
@@ -116,7 +116,7 @@ export const QUERY_PARAM_DEFAULTS = {
     endDate,
     graphType: 'area',
     page: 0,
-    q: '',
+    startsWith: '',
     selectedIds: [],
     selectedQueue: '',
     selectedStatus: '',
@@ -134,8 +134,8 @@ const initialState = {
     jobsById: {},
     logsById: {},
     page: 0,
-    q: '',
-    qTemp: '',
+    startsWith: '',
+    startsWithTemp: '',
     queues: [],
     selectedIds: [],
     selectedQueue: 'all',
@@ -207,17 +207,17 @@ actions[SET_PAGE] = (state, { payload }) => {
     };
 };
 
-actions[SET_SEARCH] = (state, { payload }) => {
+actions[SET_STARTS_WITH] = (state, { payload }) => {
     return {
         ...state,
-        q: payload
+        startsWith: payload
     };
 };
 
-actions[SET_SEARCH_TEMP] = (state, { payload }) => {
+actions[SET_STARTS_WITH_TEMP] = (state, { payload }) => {
     return {
         ...state,
-        qTemp: payload
+        startsWithTemp: payload
     };
 };
 
@@ -324,17 +324,17 @@ export function setPage(page) {
     };
 };
 
-export function setSearch(q) {
+export function setStartsWith(startsWith) {
     return {
-        type: SET_SEARCH,
-        payload: q
+        type: SET_STARTS_WITH,
+        payload: startsWith
     };
 };
 
-export function setSearchTemp(qTemp) {
+export function setStartsWithTemp(startsWithTemp) {
     return {
-        type: SET_SEARCH_TEMP,
-        payload: qTemp
+        type: SET_STARTS_WITH_TEMP,
+        payload: startsWithTemp
     };
 }
 
@@ -416,11 +416,11 @@ export function setParams(params) {
         if (params.sortColumn && params.sortDirection)
             dispatch(setSortParams(params.sortColumn, params.sortDirection));
 
-        if (params.q !== undefined)
-            dispatch(setSearch(params.q));
+        if (params.startsWith !== undefined)
+            dispatch(setStartsWith(params.startsWith));
 
-        if (params.qTemp !== undefined)
-            dispatch(setSearchTemp(params.qTemp));
+        if (params.startsWithTemp !== undefined)
+            dispatch(setStartsWithTemp(params.startsWithTemp));
 
         if (params.page !== undefined)
             dispatch(setPage(params.page));
@@ -507,7 +507,7 @@ export function fetchJobs() {
         const state = getState();
         const params = {
             page: state.job.page,
-            q: state.job.q,
+            startsWith: state.job.startsWith,
             sortDirection: state.job.sortDirection,
             sortColumn: state.job.sortColumn
         };

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -41,13 +41,13 @@ type KillTasks struct {
 	IDs []string `json:"ids" form:"ids" query:"ids"`
 }
 
-// Find is a request handler, returns json with jobs matching the query param 'q'
+// Find is a request handler, returns json with jobs matching the query param 'startsWith'
 func (s *Server) Find(c echo.Context) error {
 	span := opentracing.StartSpan("API.Find")
 	defer span.Finish()
 
 	c.QueryParams()
-	search := c.QueryParam("q")
+	startsWith := c.QueryParam("startsWith")
 	queuesStr := c.QueryParam("queue")
 	statusStr := c.QueryParam("status")
 	column := c.QueryParam("sortColumn")
@@ -69,13 +69,13 @@ func (s *Server) Find(c echo.Context) error {
 	}
 
 	foundJobs, err := s.Storage.Find(&jobs.Options{
-		Search:  search,
-		Limit:   defaultQueryLimit,
-		Offset:  page * defaultQueryLimit,
-		Queues:  queues,
-		SortBy:  column,
-		SortAsc: sort,
-		Status:  status,
+		StartsWith: startsWith,
+		Limit:      defaultQueryLimit,
+		Offset:     page * defaultQueryLimit,
+		Queues:     queues,
+		SortBy:     column,
+		SortAsc:    sort,
+		Status:     status,
 	})
 
 	if err != nil {
@@ -110,7 +110,7 @@ func (s *Server) GetStatus(c echo.Context) error {
 	}
 }
 
-// FindOne is a request handler, returns a job matching the query parameter 'q'
+// FindOne is a request handler, returns a job matching the query parameter 'id'
 func (s *Server) FindOne(c echo.Context) error {
 	span := opentracing.StartSpan("API.FindOne")
 	defer span.Finish()

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -99,13 +99,13 @@ type StatusSummary struct {
 
 // Options is the query options for the Find method to use
 type Options struct {
-	Search  string
-	Limit   int
-	Offset  int
-	Queues  []string
-	SortBy  string
-	SortAsc bool
-	Status  []string
+	StartsWith string
+	Limit      int
+	Offset     int
+	Queues     []string
+	SortBy     string
+	SortAsc    bool
+	Status     []string
 }
 
 type JobStatsOptions struct {

--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -105,7 +105,7 @@ func (pq *postgreSQLStore) Find(opts *Options) ([]*Job, error) {
 
 	// Split search into tokens (separated by whitespace). We will search for each token separately.
 	// If search is empty or only whitespace, tokens will be an empty array.
-	tokens := strings.Fields(opts.Search)
+	tokens := strings.Fields(opts.StartsWith)
 	for _, token := range tokens {
 		glob_search := "%" + searchEscape(token) + "%"
 		args = append(args, glob_search)


### PR DESCRIPTION
Rename the "q" parameter to "startsWith". This is because we will have 2 fields in the UI: Starts With and Contains. Starts With should be faster, but Contains will look for strings in the middle of the job name.