### PR TITLE
UDP-3844: Upgrade Go to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.21
 
 RUN mkdir -p /go/src/github.com/AdRoll/batchiepatchie
 WORKDIR /go/src/github.com/AdRoll/batchiepatchie


### PR DESCRIPTION
# The Problem

docker-compose up was giving this error:

```
#11 10.56 # github.com/go-delve/delve/pkg/proc/gdbserial
#11 10.56 /go/pkg/mod/github.com/go-delve/delve@v1.23.0/pkg/proc/gdbserial/rr.go:247:35: undefined: strings.CutPrefix
#11 10.56 /go/pkg/mod/github.com/go-delve/delve@v1.23.0/pkg/proc/gdbserial/rr.go:248:33: undefined: strings.CutPrefix
#11 10.56 note: module requires Go 1.21
```

# The Solution

Upgrade Go from 1.18 to 1.21