### PR TITLE
UDP-3844: Fix nil pointer dereference

### DIFF
--- a/syncer/batchsync.go
+++ b/syncer/batchsync.go
@@ -122,14 +122,16 @@ func syncJobsStatus(storer jobs.Storer, status string, queues []string, job_summ
 				}
 
 				timeout := -1
-				for _, value := range desc.Container.Environment {
-					if *value.Name == "PYBATCH_TIMEOUT" {
-						timeout, err = strconv.Atoi(*value.Value)
-						if err != nil {
-							timeout = -1
-							log.Warning("PYBATCH_TIMEOUT contains unparseable ", value.Value, " : ", err)
+				if desc.Container != nil {
+					for _, value := range desc.Container.Environment {
+						if *value.Name == "PYBATCH_TIMEOUT" {
+							timeout, err = strconv.Atoi(*value.Value)
+							if err != nil {
+								timeout = -1
+								log.Warning("PYBATCH_TIMEOUT contains unparseable ", value.Value, " : ", err)
+							}
+							break
 						}
-						break
 					}
 				}
 
@@ -140,10 +142,13 @@ func syncJobsStatus(storer jobs.Storer, status string, queues []string, job_summ
 					stopped_at = &tmp
 				}
 
-				command_line_json, err := json.Marshal(desc.Container.Command)
-				if err != nil {
-					log.Warning("Cannot marshal command line to JSON: ", err)
-					continue
+				command_line_json := []byte{}
+				if desc.Container != nil {
+					command_line_json, err = json.Marshal(desc.Container.Command)
+					if err != nil {
+						log.Warning("Cannot marshal command line to JSON: ", err)
+						continue
+					}
 				}
 
 				status_reason := ""
@@ -183,11 +188,11 @@ func syncJobsStatus(storer jobs.Storer, status string, queues []string, job_summ
 					}
 				}
 
-				if log_stream_name == nil && desc.Container.LogStreamName != nil {
+				if log_stream_name == nil && desc.Container != nil && desc.Container.LogStreamName != nil {
 					var lsn = *desc.Container.LogStreamName
 					log_stream_name = &lsn
 				}
-				if (task_arn == nil || *task_arn == "") && desc.Container.TaskArn != nil {
+				if (task_arn == nil || *task_arn == "") && desc.Container != nil && desc.Container.TaskArn != nil {
 					task_arn_c := *desc.Container.TaskArn
 					task_arn = &task_arn_c
 				}


### PR DESCRIPTION
# The Problem

This error was occurring on startup:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xa99cf5]

goroutine 114 [running]:
github.com/AdRoll/batchiepatchie/syncer.syncJobsStatus({0x7f72d07369d8, 0xc0004cc6d8}, {0xd91af9, 0x6}, {0xc000501000, 0x40, 0xc000a3fbd8?}, 0x47a99b?, {0x10313c0, 0xc0003b4378})
        /go/src/github.com/AdRoll/batchiepatchie/syncer/batchsync.go:125 +0xed5
github.com/AdRoll/batchiepatchie/syncer.syncJobs({0x7f72d07369d8, 0xc0004cc6d8}, {0xc000501000, 0x40, 0x40})
        /go/src/github.com/AdRoll/batchiepatchie/syncer/batchsync.go:267 +0x2bd
github.com/AdRoll/batchiepatchie/syncer.RunSynchronizer({0x1032770?, 0xc0004cc6d8}, {0xc000501000, 0x40, 0x40})
        /go/src/github.com/AdRoll/batchiepatchie/syncer/batchsync.go:354 +0x65
github.com/AdRoll/batchiepatchie/syncer.RunPeriodicSynchronizer.func1()
        /go/src/github.com/AdRoll/batchiepatchie/syncer/batchsync.go:339 +0x1b3
created by github.com/AdRoll/batchiepatchie/syncer.RunPeriodicSynchronizer
        /go/src/github.com/AdRoll/batchiepatchie/syncer/batchsync.go:315 +0xab
```

# The Solution

Add nil checks.