### PR TITLE
Speed up batchiepatchie by adding a date-range filter that defaults to 1 day

### DIFF
--- a/frontend/src/components/Search/Search.jsx
+++ b/frontend/src/components/Search/Search.jsx
@@ -28,6 +28,7 @@ class Search extends React.Component {
     static propTypes = {
         loading: PropTypes.bool.isRequired,
         qTemp: PropTypes.string.isRequired,
+        dateRange: PropTypes.string.isRequired,
         setParams: PropTypes.func.isRequired,
         statusKey: PropTypes.string.isRequired,
     };
@@ -35,7 +36,8 @@ class Search extends React.Component {
     render() {
         const {
             loading,
-            qTemp
+            qTemp,
+            dateRange
         } = this.props;
 
         return (
@@ -44,7 +46,22 @@ class Search extends React.Component {
                     <div className='col-md-3'>
                         { loading && <SectionLoader /> }
                     </div>
-                    <div className='col-md-9'>
+                    <div className='col-md-3'>
+                        <select
+                            className="form-control"
+                            value={dateRange}
+                            onChange={this.onDateRangeChanged}
+                        >
+                            <option value="10m">The past 10 minutes</option>
+                            <option value="1h">The past hour</option>
+                            <option value="1d">The past day</option>
+                            <option value="2d">The past 2 days</option>
+                            <option value="3d">The past 3 days</option>
+                            <option value="7d">The past 7 days</option>
+                            <option value="30d">The past 30 days</option>
+                        </select>
+                    </div>
+                    <div className='col-md-6'>
                         <div className='input-group'>
                             <span className='input-group-addon'>
                                 <i className='fa fa-search' />
@@ -79,6 +96,10 @@ class Search extends React.Component {
         this.search(e.target.value);
     }
 
+    onDateRangeChanged = (e) => {
+        this.props.setParams({dateRange: e.target.value});
+    }
+
     search = debounce((q) => {
         this.props.setParams({q});
     }, 500)
@@ -95,6 +116,7 @@ const mapStateToProps = state => {
     return {
         statusKey,
         qTemp: state.job.qTemp,
+        dateRange: state.job.dateRange,
         loading: state.status[statusKey].loading
     };
 };

--- a/frontend/src/pages/JobsPage/JobsPage.jsx
+++ b/frontend/src/pages/JobsPage/JobsPage.jsx
@@ -126,6 +126,7 @@ class JobsPage extends React.Component {
         jobs: PropTypes.array.isRequired,
         killJobs: PropTypes.func.isRequired,
         q: PropTypes.string,
+        dateRange: PropTypes.string,
         routing: PropTypes.object.isRequired,
         selectedIds: PropTypes.array.isRequired,
         setParams: PropTypes.func.isRequired,
@@ -153,6 +154,7 @@ class JobsPage extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.q !== prevProps.q ||
+            this.props.dateRange !== prevProps.dateRange ||
             this.props.sortColumn !== prevProps.sortColumn ||
             this.props.sortDirection !== prevProps.sortDirection ||
             this.props.page !== prevProps.page ||
@@ -315,6 +317,7 @@ class JobsPage extends React.Component {
             ...QUERY_PARAM_DEFAULTS,
             ...query,
             qTemp: query.q || '',
+            dateRange: query.dateRange || '1d',
             page: query.page ? parseInt(query.page) : 0,
             selectedIds: query.selectedIds ? query.selectedIds.split(',') : [],
             selectedQueue: !query.selectedQueue ? 'all' : query.selectedQueue,
@@ -343,6 +346,7 @@ class JobsPage extends React.Component {
 
 const mapStateToProps = state => ({
     q: state.job.q,
+    dateRange: state.job.dateRange,
     jobs: state.job.jobs,
     page: state.job.page,
     height: state.layout.height,

--- a/frontend/src/stores/job.js
+++ b/frontend/src/stores/job.js
@@ -24,6 +24,7 @@ export const SET_PAGE = 'SET_PAGE';
 export const SET_QUEUES = 'SET_QUEUES';
 export const SET_SEARCH = 'SET_SEARCH';
 export const SET_SEARCH_TEMP = 'SET_SEARCH_TEMP';
+export const SET_DATE_RANGE = 'SET_DATE_RANGE';
 export const SET_SELECTED_IDS = 'SET_SELECTED_IDS';
 export const SET_SELECTED_QUEUE = 'SET_SELECTED_QUEUE';
 export const SET_SELECTED_STATUS = 'SET_SELECTED_STATUS';
@@ -117,6 +118,7 @@ export const QUERY_PARAM_DEFAULTS = {
     graphType: 'area',
     page: 0,
     q: '',
+    dateRange: '1d',
     selectedIds: [],
     selectedQueue: '',
     selectedStatus: '',
@@ -135,6 +137,7 @@ const initialState = {
     logsById: {},
     page: 0,
     q: '',
+    dateRange: '1d',
     qTemp: '',
     queues: [],
     selectedIds: [],
@@ -211,6 +214,13 @@ actions[SET_SEARCH] = (state, { payload }) => {
     return {
         ...state,
         q: payload
+    };
+};
+
+actions[SET_DATE_RANGE] = (state, { payload }) => {
+    return {
+        ...state,
+        dateRange: payload
     };
 };
 
@@ -331,6 +341,13 @@ export function setSearch(q) {
     };
 };
 
+export function setDateRange(dateRange) {
+    return {
+        type: SET_DATE_RANGE,
+        payload: dateRange
+    };
+};
+
 export function setSearchTemp(qTemp) {
     return {
         type: SET_SEARCH_TEMP,
@@ -418,6 +435,9 @@ export function setParams(params) {
 
         if (params.q !== undefined)
             dispatch(setSearch(params.q));
+
+        if (params.dateRange !== undefined)
+            dispatch(setDateRange(params.dateRange));
 
         if (params.qTemp !== undefined)
             dispatch(setSearchTemp(params.qTemp));
@@ -515,6 +535,7 @@ export function fetchJobs() {
         const params = {
             page: state.job.page,
             q: state.job.q,
+            dateRange: state.job.dateRange,
             sortDirection: state.job.sortDirection,
             sortColumn: state.job.sortColumn
         };

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -48,6 +48,7 @@ func (s *Server) Find(c echo.Context) error {
 
 	c.QueryParams()
 	search := c.QueryParam("q")
+	dateRange := c.QueryParam("dateRange")
 	queuesStr := c.QueryParam("queue")
 	statusStr := c.QueryParam("status")
 	column := c.QueryParam("sortColumn")
@@ -69,13 +70,14 @@ func (s *Server) Find(c echo.Context) error {
 	}
 
 	foundJobs, err := s.Storage.Find(&jobs.Options{
-		Search:  search,
-		Limit:   defaultQueryLimit,
-		Offset:  page * defaultQueryLimit,
-		Queues:  queues,
-		SortBy:  column,
-		SortAsc: sort,
-		Status:  status,
+		Search:    search,
+		DateRange: dateRange,
+		Limit:     defaultQueryLimit,
+		Offset:    page * defaultQueryLimit,
+		Queues:    queues,
+		SortBy:    column,
+		SortAsc:   sort,
+		Status:    status,
 	})
 
 	if err != nil {

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -99,21 +99,22 @@ type StatusSummary struct {
 
 // Options is the query options for the Find method to use
 type Options struct {
-	Search  string
-	Limit   int
-	Offset  int
-	Queues  []string
-	SortBy  string
-	SortAsc bool
-	Status  []string
+	Search    string
+	DateRange string
+	Limit     int
+	Offset    int
+	Queues    []string
+	SortBy    string
+	SortAsc   bool
+	Status    []string
 }
 
 type JobStatsOptions struct {
-	Queues    []string
-	Status    []string
-	Interval  int64
-	Start     int64
-	End       int64
+	Queues   []string
+	Status   []string
+	Interval int64
+	Start    int64
+	End      int64
 }
 
 type JobStats struct {

--- a/jobs/postgres_store.go
+++ b/jobs/postgres_store.go
@@ -101,7 +101,26 @@ func (pq *postgreSQLStore) Find(opts *Options) ([]*Job, error) {
 	args = append(args, opts.Limit)
 	args = append(args, opts.Offset)
 
-	whereClausesScan = append(whereClausesScan, "last_updated > (now() - interval '30 days')")
+	var interval string
+	switch opts.DateRange {
+	case "10m":
+		interval = "10 minutes"
+	case "1h":
+		interval = "1 hour"
+	case "1d":
+		interval = "1 day"
+	case "2d":
+		interval = "2 days"
+	case "3d":
+		interval = "3 days"
+	case "7d":
+		interval = "7 days"
+	case "30d":
+		interval = "30 days"
+	default:
+		interval = "30 days"
+	}
+	whereClausesScan = append(whereClausesScan, fmt.Sprintf("last_updated > (now() - interval '%s')", interval))
 
 	// Split search into tokens (separated by whitespace). We will search for each token separately.
 	// If search is empty or only whitespace, tokens will be an empty array.


### PR DESCRIPTION
Note: This PR has been split into smaller commits for easier review.

This PR dramatically speeds up batchiepatchie by adding a date filter. If you choose 1 day, queries that used to time out (because they were hardcoded to look back 30 days) will load in under 1 second.

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/69f6e45a-c757-4044-82dd-46f0d144e542">
