### PR TITLE
Add database cleanup v2

### DIFF
--- a/batchiepatchie-dockercompose-config.toml
+++ b/batchiepatchie-dockercompose-config.toml
@@ -9,3 +9,5 @@ database_password = "123456"
 frontend_assets = "local"
 frontend_assets_local_prefix = "frontend/dist"
 use_auto_scaler = false
+use_cleaner = true
+clean_period = 30 # seconds

--- a/batchiepatchie.go
+++ b/batchiepatchie.go
@@ -119,6 +119,12 @@ func main() {
 	} else {
 		log.Info("Auto-scaler disabled.")
 	}
+	// Launch the periodic cleaner
+	if config.Conf.UseCleaner {
+		syncer.RunPeriodicCleaner(storage)
+	} else {
+		log.Info("Cleaner disabled.")
+	}
 
 	// handle.Server is a structure to save context shared between requests
 	s := &handlers.Server{

--- a/config/config.go
+++ b/config/config.go
@@ -44,12 +44,14 @@ type Config struct {
 
 	SyncPeriod  int `toml:"sync_period"`
 	ScalePeriod int `toml:"scale_period"`
+	CleanPeriod int `toml:"clean_period"`
 
 	KillStuckJobs bool `toml:"kill_stuck_jobs"`
 
 	UseDatadogTracing bool `toml:"use_datadog_tracing"`
 
 	UseAutoScaler bool `toml:"use_auto_scaler"`
+	UseCleaner    bool `toml:"use_cleaner"`
 }
 
 // Store config in a global variable
@@ -78,8 +80,10 @@ func ReadConfiguration(filename string) error {
 		// Default values here
 		SyncPeriod:    30,
 		ScalePeriod:   30,
+		CleanPeriod:   30 * 60 * 1000 * 1000 * 1000, // 30 minutes
 		KillStuckJobs: false,
 		UseAutoScaler: true,
+		UseCleaner:    false,
 	}
 	if _, err := toml.Decode(string(tomlData), &Conf); err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,9 @@ type Config struct {
 	FrontendAssetsBucket      string `toml:"frontend_assets_bucket"`
 	FrontendAssetsKey         string `toml:"frontend_assets_key"`
 
-	SyncPeriod  int `toml:"sync_period"`
-	ScalePeriod int `toml:"scale_period"`
-	CleanPeriod int `toml:"clean_period"`
+	SyncPeriod  int64 `toml:"sync_period"`
+	ScalePeriod int64 `toml:"scale_period"`
+	CleanPeriod int64 `toml:"clean_period"`
 
 	KillStuckJobs bool `toml:"kill_stuck_jobs"`
 
@@ -80,7 +80,7 @@ func ReadConfiguration(filename string) error {
 		// Default values here
 		SyncPeriod:    30,
 		ScalePeriod:   30,
-		CleanPeriod:   30 * 60 * 1000 * 1000 * 1000, // 30 minutes
+		CleanPeriod:   30 * 60, // 30 minutes in seconds
 		KillStuckJobs: false,
 		UseAutoScaler: true,
 		UseCleaner:    false,

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -201,6 +201,12 @@ type Storer interface {
 	SubscribeToJobStatus(jobID string) (<-chan Job, func())
 }
 
+// Cleaner allows you to clean the database
+type Cleaner interface {
+	// CleanOldJobs cleans old jobs from the database
+	CleanOldJobs() error
+}
+
 // Killer is an interface to kill jobs in the queue
 type Killer interface {
 	// KillOne kills a job matching the query

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -205,6 +205,9 @@ type Storer interface {
 type Cleaner interface {
 	// CleanOldJobs cleans old jobs from the database
 	CleanOldJobs() error
+
+	// CleanOldInstanceEventLogs cleans old instance event logs from the database
+	CleanOldInstanceEventLogs() error
 }
 
 // Killer is an interface to kill jobs in the queue

--- a/syncer/batchsync.go
+++ b/syncer/batchsync.go
@@ -382,3 +382,15 @@ func RunSynchronizer(fs jobs.FinderStorer, queues []string) error {
 
 	return nil
 }
+
+func RunPeriodicCleaner(cleaner jobs.Cleaner) {
+	go func() {
+		for {
+			err := cleaner.CleanOldJobs()
+			if err != nil {
+				log.Error("Cannot clean old jobs: ", err)
+			}
+			time.Sleep(time.Second * time.Duration(config.Conf.CleanPeriod))
+		}
+	}()
+}

--- a/syncer/batchsync.go
+++ b/syncer/batchsync.go
@@ -390,6 +390,10 @@ func RunPeriodicCleaner(cleaner jobs.Cleaner) {
 			if err != nil {
 				log.Error("Cannot clean old jobs: ", err)
 			}
+			err = cleaner.CleanOldInstanceEventLogs()
+			if err != nil {
+				log.Error("Cannot clean old instance event logs: ", err)
+			}
 			time.Sleep(time.Second * time.Duration(config.Conf.CleanPeriod))
 		}
 	}()


### PR DESCRIPTION
Add a new _cleaner_ subsystem to batchiepatchie. It would periodically clear the tables:

- `jobs`
- `task_arns_to_instance_info`
- `instance_event_log`

These tables contain somewhat transient data, and they grow linearly over the years.

Last time we cleaned up our batchiepatchie instance that had been running for some odd 9 years, the jobs table was up to 500GB.